### PR TITLE
Alterado auto_increment para autoincrement em src/main.php

### DIFF
--- a/src/main.php
+++ b/src/main.php
@@ -31,7 +31,7 @@ function create_todos_table(PDO $pdo)
 {
     return $pdo->exec('
         create table if not exists todos (
-            id integer not null primary key auto_increment,
+            id integer not null primary key autoincrement,
             title varchar(255) not null,
             done bool not null default false,
             created_at datetime not null default current_timestamp


### PR DESCRIPTION
Ao rodar o projeto, o erro a seguir ocorre por causa do auto_increment ao invés de autoincrement (ocorre quando cria-se um novo db.sqlite e a tabela todos precisa ser criada na primeira execução)

127.0.0.1:54156 [500]: GET / - Uncaught PDOException: SQLSTATE[HY000]: General error: 1 near "auto_increment": syntax error in /home/antonio/Projetos/crud-php/src/main.php:32
